### PR TITLE
Fix package icon issue and simplify workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,8 +32,9 @@ jobs:
       
       - name: Build and pack
         run: |
-          dotnet build src/Blake2Fast/Blake2Fast.csproj -c Release -p:PackageId=SAIB.Blake2Fast -p:Version=${{ steps.get_version.outputs.VERSION }}
-          dotnet pack src/Blake2Fast/Blake2Fast.csproj -c Release -p:PackageId=SAIB.Blake2Fast -p:Version=${{ steps.get_version.outputs.VERSION }} --output nuget-packages
+          # We don't need to specify PackageId here as it's in the project file
+          dotnet build src/Blake2Fast/Blake2Fast.csproj -c Release -p:Version=${{ steps.get_version.outputs.VERSION }}
+          dotnet pack src/Blake2Fast/Blake2Fast.csproj -c Release -p:Version=${{ steps.get_version.outputs.VERSION }} --output nuget-packages
       
       - name: Run tests
         run: dotnet test tests/Blake.Test -c Release

--- a/src/Blake2Fast/Blake2Fast.csproj
+++ b/src/Blake2Fast/Blake2Fast.csproj
@@ -10,6 +10,9 @@
 		<PackageLicenseExpression>CC0-1.0</PackageLicenseExpression>
 		<RepositoryUrl>https://github.com/SAIB-Inc/Blake2Fast</RepositoryUrl>
 		<PackageTags>blake2;blake3;hash;crypto;cryptography;hmac</PackageTags>
+		<!-- Explicitly remove the package icon to override inherited properties -->
+		<PackageIcon></PackageIcon>
+		<Owners>SAIB</Owners>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
- Explicitly remove PackageIcon property to avoid icon not found error
- Set Owners property to override inherited SauceControl value
- Simplify workflow build command since PackageId is in the project file